### PR TITLE
Host nightly R packages on S3 instead of Bintray

### DIFF
--- a/.github/workflows/build-binary-packages.yml
+++ b/.github/workflows/build-binary-packages.yml
@@ -7,7 +7,7 @@ on:
   push:
     paths:
       - '.github/workflows/build-binary-packages.yml'
-      - bintray-upload.sh
+      - s3-upload.py
       - build-binary-and-upload.R
 
 jobs:
@@ -28,12 +28,20 @@ jobs:
     steps:
       - name: Checkout arrow-r-nightly
         uses: actions/checkout@v2
+      - name: Set up Python (for S3 upload)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install Boto
+        run: |
+          python -m pip install boto3
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.r_version }}
           Ncpus: 2
       - name: Build and upload
         env:
-          BINTRAY_APIKEY: ${{ secrets.BINTRAY_APIKEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: Rscript {0}
         run: source("build-binary-and-upload.R")

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/build-binary.yml'
       - 'linux/*'
       - s3-upload.py
+      - bintray-upload.sh
       - up-date-description.sh
   # On tag too?
 
@@ -67,9 +68,9 @@ jobs:
           # These files were created by the docker user so we have to sudo to get them
           sudo -E zip -r $PKG_FILE lib/*.a include/
           export REPO_PATH=/libarrow/bin/${{ matrix.config.os }}-${{ matrix.config.version }}
-          python ../../../../../s3-upload.py $PKG_FILE $REPO_PATH
-          # This is in case we want to keep putting the CRAN release C++ binaries on bintray
-          # sudo -E bash ../../../../../bintray-upload.sh
+          sudo -E bash ../../../../../bintray-upload.sh
+          # Or, upload to S3
+          # python ../../../../../s3-upload.py $PKG_FILE $REPO_PATH
   windows:
     name: C++ Binary Windows RTools (35 and 40)
     runs-on: windows-latest
@@ -126,6 +127,7 @@ jobs:
           python -m pip install boto3
       - name: Upload
         env:
+          BINTRAY_APIKEY: ${{ secrets.BINTRAY_APIKEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: bash
@@ -133,4 +135,6 @@ jobs:
           cd build
           export PKG_FILE=$(ls arrow-*.zip)
           export REPO_PATH=/libarrow/bin/windows
-          python ../s3-upload.py $PKG_FILE $REPO_PATH
+          source ../bintray-upload.sh
+          # Or, upload to S3
+          # python ../s3-upload.py $PKG_FILE $REPO_PATH

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - '.github/workflows/build-binary.yml'
       - 'linux/*'
-      - bintray-upload.sh
+      - s3-upload.py
       - up-date-description.sh
   # On tag too?
 
@@ -44,9 +44,18 @@ jobs:
           cd linux
           docker-compose build ${{ matrix.config.os }}
           docker-compose run ${{ matrix.config.os }}
+      - name: Set up Python (for S3 upload)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install Boto
+        run: |
+          python -m pip install boto3
       - name: Bundle and upload
         env:
           BINTRAY_APIKEY: ${{ secrets.BINTRAY_APIKEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
           cd linux/arrow/r
@@ -58,7 +67,9 @@ jobs:
           # These files were created by the docker user so we have to sudo to get them
           sudo -E zip -r $PKG_FILE lib/*.a include/
           export REPO_PATH=/libarrow/bin/${{ matrix.config.os }}-${{ matrix.config.version }}
-          sudo -E bash ../../../../../bintray-upload.sh
+          python ../../../../../s3-upload.py $PKG_FILE $REPO_PATH
+          # This is in case we want to keep putting the CRAN release C++ binaries on bintray
+          # sudo -E bash ../../../../../bintray-upload.sh
   windows:
     name: C++ Binary Windows RTools (35 and 40)
     runs-on: windows-latest
@@ -106,12 +117,20 @@ jobs:
           ARROW_HOME: "arrow"
           RTOOLS_VERSION: 35
         run: arrow/ci/scripts/r_windows_build.sh
+      - name: Set up Python (for S3 upload)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install Boto
+        run: |
+          python -m pip install boto3
       - name: Upload
         env:
-          BINTRAY_APIKEY: ${{ secrets.BINTRAY_APIKEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
           cd build
           export PKG_FILE=$(ls arrow-*.zip)
           export REPO_PATH=/libarrow/bin/windows
-          source ../bintray-upload.sh
+          python ../s3-upload.py $PKG_FILE $REPO_PATH

--- a/.github/workflows/build-source.yml
+++ b/.github/workflows/build-source.yml
@@ -7,7 +7,7 @@ on:
   push:
     paths:
       - '.github/workflows/build-source.yml'
-      - bintray-upload.sh
+      - s3-upload.py
       - up-date-description.sh
 
 jobs:
@@ -29,20 +29,29 @@ jobs:
           cd r
           export DATE=$(date -d yesterday +%Y%m%d)
           source ../../up-date-description.sh
+      - name: Set up Python (for S3 upload)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install Boto
+        run: |
+          python -m pip install boto3
       - name: Build and upload cpp bundle
         env:
-          BINTRAY_APIKEY: ${{ secrets.BINTRAY_APIKEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
           cd arrow
           VERSION=$(grep ^Version r/DESCRIPTION | sed s/Version:\ //)
           zip -r arrow-${VERSION}.zip cpp/build-support/ cpp/cmake_modules/ cpp/src/ cpp/thirdparty/ cpp/tools/ cpp/CMakeLists.txt cpp/README.md LICENSE.txt NOTICE.txt .env
-          PKG_FILE=arrow-${VERSION}.zip REPO_PATH=/libarrow/src source ../bintray-upload.sh
+          python ../s3-upload.py arrow-${VERSION}.zip libarrow/src
       - name: Install R
         uses: r-lib/actions/setup-r@master
       - name: Build and upload R source package
         env:
-          BINTRAY_APIKEY: ${{ secrets.BINTRAY_APIKEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
           cd arrow/r
@@ -53,4 +62,8 @@ jobs:
           rm -f apache-arrow.rb.bak
           cd ..
           R CMD build --no-build-vignettes .
-          PKG_FILE=arrow_*.tar.gz PKG_TYPE=source source ../../bintray-upload.sh
+          Rscript -e 'tools::write_PACKAGES(".", type = "source")'
+          python ../../s3-upload.py arrow_*.tar.gz src/contrib
+          python ../../s3-upload.py PACKAGES src/contrib
+          python ../../s3-upload.py PACKAGES.gz src/contrib
+          python ../../s3-upload.py PACKAGES.rds src/contrib

--- a/.github/workflows/build-source.yml
+++ b/.github/workflows/build-source.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/build-source.yml'
       - s3-upload.py
+      - bintray-upload.sh
       - up-date-description.sh
 
 jobs:
@@ -38,6 +39,7 @@ jobs:
           python -m pip install boto3
       - name: Build and upload cpp bundle
         env:
+          BINTRAY_APIKEY: ${{ secrets.BINTRAY_APIKEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: bash
@@ -45,7 +47,9 @@ jobs:
           cd arrow
           VERSION=$(grep ^Version r/DESCRIPTION | sed s/Version:\ //)
           zip -r arrow-${VERSION}.zip cpp/build-support/ cpp/cmake_modules/ cpp/src/ cpp/thirdparty/ cpp/tools/ cpp/CMakeLists.txt cpp/README.md LICENSE.txt NOTICE.txt .env
-          python ../s3-upload.py arrow-${VERSION}.zip libarrow/src
+          PKG_FILE=arrow-${VERSION}.zip REPO_PATH=/libarrow/src source ../bintray-upload.sh
+          # Or to upload to S3:
+          # python ../s3-upload.py arrow-${VERSION}.zip libarrow/src
       - name: Install R
         uses: r-lib/actions/setup-r@master
       - name: Build and upload R source package
@@ -60,6 +64,8 @@ jobs:
           cd tools
           sed -i.bak -E -e 's/arrow.git"$/arrow.git", :revision => "'"$(git rev-list -n 1 HEAD)"'"/' apache-arrow.rb
           rm -f apache-arrow.rb.bak
+          # NOTE: if you want to change the source of the libarrow files away
+          # from bintray, sed linuxlibs.R and winlibs.R
           cd ..
           R CMD build --no-build-vignettes .
           Rscript -e 'tools::write_PACKAGES(".", type = "source")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: r
 os: osx
 cache: packages
 fortran: false
+latex: false
 r:
 # - 3.2
 # - 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
 # if there is no DESCRIPTION file found
 - pwd
 script:
-- python -m pip install boto3
+- python3 -m pip install boto3
 - Rscript build-binary-and-upload.R

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ install:
 # if there is no DESCRIPTION file found
 - pwd
 script:
+- python -m pip install boto3
 - Rscript build-binary-and-upload.R

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@
 [![Daily pkgdown site](https://github.com/ursa-labs/arrow-r-nightly/workflows/Daily%20pkgdown%20site/badge.svg)](https://github.com/ursa-labs/arrow-r-nightly/actions?query=workflow%3A"Daily+pkgdown+site")
 
 This repository holds build scripts that pull the [`apache/arrow`](https://github.com/apache/arrow) repository and build and test the R package across several versions of R on macOS and Windows. They also build static `libarrow` C++ libraries for several Linux distributions.
-These builds are triggered daily. Binary packages generated from those jobs are then pushed to a Bintray repository at https://dl.bintray.com/ursalabs/arrow-r.
+These builds are triggered daily. C++ libraries are deployed to
+https://dl.bintray.com/ursalabs/arrow-r, and R packages generated from those jobs
+are pushed to a package repository at https://arrow-r-nightly.s3.amazonaws.com.
 
-To install the latest version, use this Bintray repository as the first entry in your `"repos"` argument, ahead of your CRAN mirror, like
+To install the latest version, use this repository as the first entry in your `"repos"` argument, ahead of your CRAN mirror, like
 
 ```r
-install.packages("arrow", repos = c("https://dl.bintray.com/ursalabs/arrow-r", getOption("repos")))
+install.packages("arrow", repos = c("https://arrow-r-nightly.s3.amazonaws.com", getOption("repos")))
 ```
+
+> Note: nightly packages were previously hosted at https://dl.bintray.com/ursalabs/arrow-r. Note the new URL.
 
 These daily package builds are not official Apache releases and are not recommended for production use. They may be useful for testing bug fixes and new features under active development.
 

--- a/build-binary-and-upload.R
+++ b/build-binary-and-upload.R
@@ -3,7 +3,9 @@ on_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
 # Install dependencies by installing (yesterday's) binary, then removing it
 install.packages("arrow",
   type = "binary",
-  repos = c("https://dl.bintray.com/ursalabs/arrow-r", "https://cloud.r-project.org")
+  repos = "https://cloud.r-project.org"
+  # Don't try bintray while we're migrating things
+  # repos = c("https://dl.bintray.com/ursalabs/arrow-r", "https://cloud.r-project.org")
 )
 remove.packages("arrow")
 
@@ -16,7 +18,7 @@ if (!on_windows) {
 }
 install.packages("arrow",
   type = "source",
-  repos = "https://arrow-r-nightly.s3.us-east-1.amazonaws.com",
+  repos = "https://arrow-r-nightly.s3.amazonaws.com",
   INSTALL_opts = INSTALL_opts
 )
 

--- a/build-binary-and-upload.R
+++ b/build-binary-and-upload.R
@@ -28,7 +28,7 @@ read_parquet(system.file("v0.7.1.parquet", package = "arrow"))
 
 # Upload
 tools::write_PACKAGES(".", type = ifelse(on_windows, "win.binary", "mac.binary"))
-
+python <- ifelse(on_windows, "python", "python3")
 repo_path <- contrib.url("", type = "binary")
 for (f in c("arrow_*.*", "PACKAGES", "PACKAGES.gz", "PACKAGES.rds")) {
   status <- system(paste(python, "s3-upload.py", f, repo_path))

--- a/build-binary-and-upload.R
+++ b/build-binary-and-upload.R
@@ -16,7 +16,7 @@ if (!on_windows) {
 }
 install.packages("arrow",
   type = "source",
-  repos = "https://dl.bintray.com/ursalabs/arrow-r",
+  repos = "https://arrow-r-nightly.s3.us-east-1.amazonaws.com",
   INSTALL_opts = INSTALL_opts
 )
 
@@ -27,9 +27,10 @@ read_parquet(system.file("v0.7.1.parquet", package = "arrow"))
 # Upload
 tools::write_PACKAGES(".", type = ifelse(on_windows, "win.binary", "mac.binary"))
 
-Sys.setenv(REPO_PATH = contrib.url("", type = "binary"))
-bash <- ifelse(on_windows, '"C:\\Program Files\\Git\\bin\\bash.EXE"', "bash")
-status <- system(paste(bash, "bintray-upload.sh"))
-if (status > 0) {
-  stop("Upload failed")
+repo_path <- contrib.url("", type = "binary")
+for (f in c("arrow_*.*", "PACKAGES", "PACKAGES.gz", "PACKAGES.rds")) {
+  status <- system(paste(python, "s3-upload.py", f, repo_path))
+  if (status > 0) {
+    stop("Upload failed")
+  }
 }

--- a/build-binary-and-upload.R
+++ b/build-binary-and-upload.R
@@ -3,9 +3,7 @@ on_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
 # Install dependencies by installing (yesterday's) binary, then removing it
 install.packages("arrow",
   type = "binary",
-  repos = "https://cloud.r-project.org"
-  # Don't try bintray while we're migrating things
-  # repos = c("https://dl.bintray.com/ursalabs/arrow-r", "https://cloud.r-project.org")
+  repos = c("https://arrow-r-nightly.s3.amazonaws.com", "https://cloud.r-project.org")
 )
 remove.packages("arrow")
 

--- a/build-binary-and-upload.R
+++ b/build-binary-and-upload.R
@@ -30,7 +30,8 @@ read_parquet(system.file("v0.7.1.parquet", package = "arrow"))
 tools::write_PACKAGES(".", type = ifelse(on_windows, "win.binary", "mac.binary"))
 python <- ifelse(on_windows, "python", "python3")
 repo_path <- contrib.url("", type = "binary")
-for (f in c("arrow_*.*", "PACKAGES", "PACKAGES.gz", "PACKAGES.rds")) {
+pkg_file <- dir(pattern = "^arrow_")
+for (f in c(pkg_file, "PACKAGES", "PACKAGES.gz", "PACKAGES.rds")) {
   status <- system(paste(python, "s3-upload.py", f, repo_path))
   if (status > 0) {
     stop("Upload failed")

--- a/linux/install-arrow.R
+++ b/linux/install-arrow.R
@@ -1,7 +1,7 @@
 source("https://raw.githubusercontent.com/apache/arrow/master/ci/etc/rprofile")
 install.packages(
   "arrow",
-  repos = c("https://dl.bintray.com/ursalabs/arrow-r", getOption("repos")),
+  repos = c("https://arrow-r-nightly.s3.us-east-1.amazonaws.com", getOption("repos")),
   verbose = TRUE
 )
 

--- a/linux/install-arrow.R
+++ b/linux/install-arrow.R
@@ -1,7 +1,7 @@
 source("https://raw.githubusercontent.com/apache/arrow/master/ci/etc/rprofile")
 install.packages(
   "arrow",
-  repos = c("https://arrow-r-nightly.s3.us-east-1.amazonaws.com", getOption("repos")),
+  repos = c("https://arrow-r-nightly.s3.amazonaws.com", getOption("repos")),
   verbose = TRUE
 )
 

--- a/linux/install-with-pkgdown.R
+++ b/linux/install-with-pkgdown.R
@@ -1,7 +1,7 @@
 source("https://raw.githubusercontent.com/apache/arrow/master/ci/etc/rprofile")
 options(
   install.packages.check.source = "no",
-  repos = c("https://dl.bintray.com/ursalabs/arrow-r", getOption("repos"))
+  repos = c("https://arrow-r-nightly.s3.us-east-1.amazonaws.com", getOption("repos"))
 )
 install.packages(c("remotes", "pkgdown"), verbose = TRUE)
 remotes::install_deps("arrow/r", dependencies = TRUE, verbose = TRUE)

--- a/linux/install-with-pkgdown.R
+++ b/linux/install-with-pkgdown.R
@@ -1,7 +1,7 @@
 source("https://raw.githubusercontent.com/apache/arrow/master/ci/etc/rprofile")
 options(
   install.packages.check.source = "no",
-  repos = c("https://arrow-r-nightly.s3.us-east-1.amazonaws.com", getOption("repos"))
+  repos = c("https://arrow-r-nightly.s3.amazonaws.com", getOption("repos"))
 )
 install.packages(c("remotes", "pkgdown"), verbose = TRUE)
 remotes::install_deps("arrow/r", dependencies = TRUE, verbose = TRUE)

--- a/s3-upload.py
+++ b/s3-upload.py
@@ -22,6 +22,9 @@ if __name__ == '__main__':
         dest_file = sys.argv[2] + "/" + os.path.basename(source_file)
     else:
         dest_file = source_file
+    if dest_file[0] == "/"
+        # Prune a leading slash, S3 doesn't handle this gracefully
+        dest_file = destfile[1:]
     print("Uploading " + dest_file)
     with open(source_file, 'rb') as data:
         boto3.resource('s3').Bucket(BUCKET).put_object(Key=dest_file, Body=data)

--- a/s3-upload.py
+++ b/s3-upload.py
@@ -24,8 +24,11 @@ if __name__ == '__main__':
         dest_file = source_file
     if dest_file[0] == "/":
         # Prune a leading slash, S3 doesn't handle this gracefully
-        dest_file = destfile[1:]
-    print("Uploading " + dest_file)
-    with open(source_file, 'rb') as data:
-        boto3.resource('s3').Bucket(BUCKET).put_object(Key=dest_file, Body=data)
-    print("Done!")
+        dest_file = dest_file[1:]
+    if "--dry-run" in sys.argv:
+        print("Dry run: would upload " + source_file + " to " + dest_file)
+    else:
+        print("Uploading " + dest_file)
+        with open(source_file, 'rb') as data:
+            boto3.resource('s3').Bucket(BUCKET).put_object(Key=dest_file, Body=data)
+        print("Done!")

--- a/s3-upload.py
+++ b/s3-upload.py
@@ -1,0 +1,28 @@
+# Usage:
+#
+# python3 s3-upload.py path/to/file-to-upload.tar.gz [path/on/s3]
+#
+# If path/on/s3 is provided, the resulting file will be path/on/s3/file-to-upload.tar.gz
+# Otherwise, it will be path/to/file-to-upload.tar.gz
+#
+# Assumes AWS credentials are set outside of this
+# (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
+# and that that user has access to write to the BUCKET specified below
+
+import os
+import sys
+
+import boto3
+
+BUCKET = 'arrow-r-nightly'
+
+if __name__ == '__main__':
+    source_file = sys.argv[1]
+    if len(sys.argv) > 2:
+        dest_file = sys.argv[2] + "/" + os.path.basename(source_file)
+    else:
+        dest_file = source_file
+    print("Uploading " + dest_file)
+    with open(source_file, 'rb') as data:
+        boto3.resource('s3').Bucket(BUCKET).put_object(Key=dest_file, Body=data)
+    print("Done!")

--- a/s3-upload.py
+++ b/s3-upload.py
@@ -8,11 +8,15 @@
 # Assumes AWS credentials are set outside of this
 # (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
 # and that that user has access to write to the BUCKET specified below
+#
+# You could use aws cli instead, but boto3 installs better across platforms
+# (i.e. Windows)
 
 import os
 import sys
 
 import boto3
+
 
 BUCKET = 'arrow-r-nightly'
 

--- a/s3-upload.py
+++ b/s3-upload.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         dest_file = sys.argv[2] + "/" + os.path.basename(source_file)
     else:
         dest_file = source_file
-    if dest_file[0] == "/"
+    if dest_file[0] == "/":
         # Prune a leading slash, S3 doesn't handle this gracefully
         dest_file = destfile[1:]
     print("Uploading " + dest_file)


### PR DESCRIPTION
Bintray does not let you keep updating the PACKAGES files indefinitely, so we can't use it to host an R repository anymore. (A "version" is locked after 365 days, so you can't add or remove any files in it. Nor can you create a new version and mask a file with the same name. Bintray support recommended creating a new repository.) So this PR moves the R packages to a public S3 bucket, https://arrow-r-nightly.s3.amazonaws.com.

We can, however, use bintray to host the `libarrow` nightly C++ source and binaries, because those don't require a package index file to be overwritten. This PR keeps the libarrow C++ on bintray since they're free in perpetuity, and also doing so means we don't have to change the R package build scripts to look somewhere else sometimes. 