### PR TITLE
bump linux map to include the two newest ubuntus

### DIFF
--- a/linux/distro-map.csv
+++ b/linux/distro-map.csv
@@ -15,3 +15,5 @@ ubuntu-18.10,ubuntu-18.04
 ubuntu-19.04,ubuntu-18.04
 ubuntu-19.10,ubuntu-18.04
 ubuntu-20.04,ubuntu-18.04
+ubuntu-20.10,ubuntu-18.04
+ubuntu-21.04,ubuntu-18.04


### PR DESCRIPTION
Adds Ubuntu releases 20.10 and 21.04 and maps them on to 18.04. I've confirmed that the most recently nightly built for 18.04 does work on 21.04.