### PR TITLE
Add ubuntu-22.04 binary to fix openssl issue

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -1,6 +1,7 @@
 name: Build and test
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -1,7 +1,6 @@
 name: Build and test
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -111,7 +111,8 @@ jobs:
         config:
         # Ubuntu 22.04 uses openssl3 so needs it's own binary
         # https://issues.apache.org/jira/browse/ARROW-16678
-          - { os: ubuntu, version: ["18.04", "22.04"] }
+          - { os: ubuntu, version: "18.04" }
+          - { os: ubuntu, version: "22.04" }
           - { os: centos, version: "7" }
     env:
       VERSION: ${{ matrix.config.version }}

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -108,7 +108,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu, version: "18.04" }
+        # Ubuntu 22.04 uses openssl3 so needs it's own binary
+        # https://issues.apache.org/jira/browse/ARROW-16678
+          - { os: ubuntu, version: ["18.04", "22.04"] }
           - { os: centos, version: "7" }
     env:
       VERSION: ${{ matrix.config.version }}

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # Ubuntu 22.04 uses openssl3 so needs it's own binary
+        # Ubuntu 22.04 uses openssl3 so needs its own binary
         # https://issues.apache.org/jira/browse/ARROW-16678
           - { os: ubuntu, version: "18.04" }
           - { os: ubuntu, version: "22.04" }

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -251,7 +251,7 @@ jobs:
           - "rocker/r-ver:3.6.3" # for debian:buster (10)
           - "rocker/r-ver" # ubuntu-20.04
           - "rhub/fedora-clang-devel" # tests distro-map.csv, mapped to ubuntu-18.04
-          - "rocker/r-ubuntu:22.04" # tests openssl3 compatability
+          - "rocker/r-ubuntu:22.04" # tests openssl3 compatibility
     steps:
       - name: Checkout arrow-r-nightly
         uses: actions/checkout@v1

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -251,6 +251,7 @@ jobs:
           - "rocker/r-ver:3.6.3" # for debian:buster (10)
           - "rocker/r-ver" # ubuntu-20.04
           - "rhub/fedora-clang-devel" # tests distro-map.csv, mapped to ubuntu-18.04
+          - "rocker/r-ubuntu:22.04" # tests openssl3 compatability
     steps:
       - name: Checkout arrow-r-nightly
         uses: actions/checkout@v1

--- a/linux/distro-map.csv
+++ b/linux/distro-map.csv
@@ -20,5 +20,5 @@ ubuntu-20.04,ubuntu-18.04
 ubuntu-20.10,ubuntu-18.04
 ubuntu-21.04,ubuntu-18.04
 ubuntu-21.10,ubuntu-18.04
-ubuntu-22.04,ubuntu-18.04
-ubuntu-22.10,ubuntu-18.04
+ubuntu-22.04,ubuntu-22.04
+ubuntu-22.10,ubuntu-22.04

--- a/linux/distro-map.csv
+++ b/linux/distro-map.csv
@@ -20,5 +20,4 @@ ubuntu-20.04,ubuntu-18.04
 ubuntu-20.10,ubuntu-18.04
 ubuntu-21.04,ubuntu-18.04
 ubuntu-21.10,ubuntu-18.04
-ubuntu-22.04,ubuntu-22.04
 ubuntu-22.10,ubuntu-22.04


### PR DESCRIPTION
Ubuntu 22.04 uses openssl3 so it is not compatible with the 18.04 binary
See: https://issues.apache.org/jira/browse/ARROW-16678

Error is reproducible:
https://github.com/assignUser/test-repo-b/runs/6651182415?check_suite_focus=true#step:4:502

22.04 binary fixes it:
https://github.com/assignUser/test-repo-b/runs/6662152060?check_suite_focus=true